### PR TITLE
Add tox, flake8, isort, and test skeleton

### DIFF
--- a/satellite/admin.py
+++ b/satellite/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/satellite/models.py
+++ b/satellite/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+# from django.db import models
 
 # Create your models here.

--- a/satellite/tests.py
+++ b/satellite/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/satellite/tests/settings.py
+++ b/satellite/tests/settings.py
@@ -1,0 +1,2 @@
+# Put any test settings that might be needed here
+SECRET_KEY = 'testing'

--- a/satellite/tests/test_models.py
+++ b/satellite/tests/test_models.py
@@ -1,0 +1,3 @@
+# from django.test import TestCase
+
+# Create your tests here.

--- a/satellite/tests/test_views.py
+++ b/satellite/tests/test_views.py
@@ -1,0 +1,3 @@
+# from django.test import TestCase
+
+# Create your tests here.

--- a/satellite/urls.py
+++ b/satellite/urls.py
@@ -1,0 +1,5 @@
+# from django.conf.urls import include, url
+
+urlpatterns = [
+    # Include url patterns here
+]

--- a/satellite/views.py
+++ b/satellite/views.py
@@ -1,3 +1,3 @@
-from django.shortcuts import render
+# from django.shortcuts import render
 
 # Create your views here.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ install_requires = [
 testing_extras = [
     'mock>=2.0.0',
     'coverage>=3.7.0',
-    'flake8>=2.2.0',
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,57 @@
+[tox]
+skipsdist=True
+envlist=lint,py{27,36}-dj{18,111} 
+
+[testenv]
+install_command=pip install -e ".[testing]" -U {opts} {packages}
+commands=
+    coverage erase
+    coverage run --source='satellite' {envbindir}/django-admin.py test {posargs}
+setenv=
+    DJANGO_SETTINGS_MODULE=satellite.tests.settings
+
+basepython=
+    py27: python2.7
+    py36: python3.6
+
+deps=
+    dj18: Django>=1.8,<1.9
+    dj111: Django>=1.11,<1.12
+
+[testenv:lint]
+basepython=python3.6
+deps=
+    flake8>=2.2.0
+    isort>=4.2.15
+commands=
+    flake8 .
+    isort --check-only --diff --recursive satellite
+
+[flake8]
+ignore = 
+    # Allow assigning lambda expressions
+    E731,
+    # Allow line breaks after binary operators
+    W503,
+
+exclude =
+    # Some of this are excluded for speed of directory traversal. Not all of 
+    # them have Python files we wish to ignore.
+    .git,
+    .tox,
+    __pycache__,
+    gulp,
+    node_modules,
+    */migrations/*.py,
+
+[settings]
+include_trailing_comma=1
+multi_line_output=3
+skip=.tox,migrations
+not_skip=__init__.py
+use_parentheses=1
+known_django=django
+known_future_library=future,six
+known_third_party=mock
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
This PR adds a skeleton setup for unit tests, a tox environment based on the documentation and examples in https://github.com/cfpb/development/pull/154. 