### PR TITLE
Add a base template to build off of

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,20 +42,20 @@ Thumbs.db
 *.swp
 
 # Python #
-#################
+##########
 *.pyc
 *.egg-info/
 __pycache__/
 *.py[cod]
 .env
+.eggs/
 
 # Django #
-#################
-*.egg-info
+##########
 .installed.cfg
 
-# Unit test / coverage reports
-#################
+# Unit test / coverage reports #
+################################
 htmlcov/
 .tox/
 .coverage

--- a/satellite/jinja2/satellite/base.html
+++ b/satellite/jinja2/satellite/base.html
@@ -1,0 +1,1 @@
+{% extends 'layout-2-1-bleedbar.html' %}

--- a/satellite/urls.py
+++ b/satellite/urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url
+from django.views.generic import TemplateView
+
+urlpatterns = [
+    url(
+        r'^$',
+        TemplateView.as_view(template_name='satellite/base.html'),
+        name='satellite_base'
+    ),
+]


### PR DESCRIPTION
Let's get this thing actually running in cfgov-refresh!

## Additions

- An empty base template
- `urls.py` to make it accessible once installed in a parent project

## Changes

- Adds `.eggs/` to `.gitignore`.

## Testing

1. Clone repo as sibling of cfgov-refresh
1. Back in cfgov-refresh's directory, `pip install -e ../django-satellite-app/`
1. Add `{'import': 'satellite', 'apps': ('satellite',)},` to `OPTIONAL_APPS` in `cfgov/cfgov/settings/base.py`
1. Add `url(r'^satellite/', include_if_app_enabled('satellite', 'satellite.urls')),` to `urlpatterns` in `cfgov/cfgov/urls.py`
1. `./runserver.sh`
1. Visit http://localhost:8000/satellite/

## Screenshots

![screen shot 2017-11-29 at 13 00 09](https://user-images.githubusercontent.com/1044670/33390903-4bd5aaca-d505-11e7-9b8d-df6cb8647287.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
