### PR TITLE
Correct paste-error in isort settings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ exclude =
     node_modules,
     */migrations/*.py,
 
-[settings]
+[isort]
 include_trailing_comma=1
 multi_line_output=3
 skip=.tox,migrations


### PR DESCRIPTION
There's a slight mistake I made when pasting from the [dev standards isort config](https://github.com/cfpb/development/blob/master/.isort.cfg) into the tox.ini file — the isort section needs to be named "`isort`" here.