### PR TITLE
Update base template to include necessary blocks

### DIFF
--- a/satellite/jinja2/satellite/base.html
+++ b/satellite/jinja2/satellite/base.html
@@ -1,1 +1,65 @@
 {% extends 'layout-2-1-bleedbar.html' %}
+
+
+{# HEAD items #}
+
+{% block title -%}
+    Page Title | Consumer Financial Protection Bureau
+{%- endblock title %}
+
+{% block desc -%}
+    Our vision is a consumer finance marketplace that works for American consumers, responsible providers, and the economy as a whole.
+{%- endblock desc %}
+
+{% block og_image -%}
+    <meta property="og:image" content="{{ meta_image_url }}">
+    <meta property="twitter:image" content="{{ meta_image_url }}">
+    {# Optional property if you want to use Twitter's large card format
+       https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image
+    <meta name="twitter:card" content="summary_large_image">
+    #}
+{%- endblock og_image %}
+
+{% block og_desc -%}
+    {{ self.desc() }}
+{%- endblock og_desc %}
+
+{% block css -%}
+    {{ super() }}
+
+    {# insert link to app-specific CSS here #}
+{%- endblock css %}
+
+
+{# BODY items #}
+
+{% block content_main scoped %}
+    <h1>Hello, world!</h1>
+
+    <p>This is the <code>content_main</code> block.</p>
+{% endblock content_main %}
+
+{% block content_sidebar scoped %}
+    <code>content_sidebar</code>
+{% endblock content_sidebar %}
+
+{% block javascript scoped -%}
+{# Conditional comment used to block IE8 and under from receiving JS #}
+<!--[if gt IE 8]><!-->
+    {# Include site-wide JavaScript. #}
+    <script src="{{ static('js/routes/common.js') }}"></script>
+
+    {# insert reference to app-specific JS here #}
+<!--<![endif]-->
+
+    <script>
+    //<![CDATA[
+        var usasearch_config = { siteHandle: 'cfpb' };
+
+        var script = document.createElement( 'script' );
+        script.type = 'text/javascript';
+        script.src = 'https://search.usa.gov/javascripts/remote.loader.js';
+        document.getElementsByTagName( 'head' )[0].appendChild( script );
+    //]]>
+    </script>
+{%- endblock javascript %}


### PR DESCRIPTION
This PR fleshes out the base template so that it has all of the main blocks needed to start creating page templates for the satellite app.

## Additions

- Lots of Jinja template blocks with default stuff in them

## Testing

1. Clone repo as sibling of cfgov-refresh
1. Back in cfgov-refresh's directory, `pip install -e ../django-satellite-app/`
1. Add `{'import': 'satellite', 'apps': ('satellite',)},` to `OPTIONAL_APPS` in `cfgov/cfgov/settings/base.py`
1. Add `url(r'^satellite/', include_if_app_enabled('satellite', 'satellite.urls')),` to `urlpatterns` in `cfgov/cfgov/urls.py`
1. `./runserver.sh`
1. Visit http://localhost:8000/satellite/

## Screenshots

<img width="1208" alt="screen shot 2017-12-05 at 13 41 46" src="https://user-images.githubusercontent.com/1044670/33624456-7906931c-d9c2-11e7-8817-2748f309b579.png">

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
